### PR TITLE
Add support for YAML-CPP 0.5+.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,13 @@ find_package(catkin REQUIRED COMPONENTS dynamixel_pro_driver roscpp roslib senso
 #find_package(Boost REQUIRED COMPONENTS system yaml-cpp)
 find_package(yaml-cpp)
 
+# There's no version hint in the yaml-cpp headers, so get the version number
+# from pkg-config.
+find_package(PkgConfig)
+pkg_check_modules(NEW_YAMLCPP yaml-cpp>=0.5)
+if(NEW_YAMLCPP_FOUND)
+add_definitions(-DHAVE_NEW_YAMLCPP)
+endif(NEW_YAMLCPP_FOUND)
 
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed

--- a/src/dynamixel_pro_controller.cpp
+++ b/src/dynamixel_pro_controller.cpp
@@ -42,6 +42,16 @@
 
 #include "yaml-cpp/yaml.h"
 
+#ifdef HAVE_NEW_YAMLCPP
+// The >> operator disappeared in yaml-cpp 0.5, so this function is
+// added to provide support for code written under the yaml-cpp 0.3 API.
+template<typename T>
+void operator >> (const YAML::Node& node, T& i)
+{
+    i = node.as<T>();
+}
+#endif
+
 #include <ros/package.h>
 #include <XmlRpcValue.h>
 
@@ -61,11 +71,16 @@ DynamixelProController::DynamixelProController()
     string path = ros::package::getPath("dynamixel_pro_controller");
     path += "/config/motor_data.yaml";
 
+    YAML::Node doc;
+
+#ifdef HAVE_NEW_YAMLCPP
+    doc = YAML::LoadFile(path);
+#else
     ifstream fin(path.c_str());
     YAML::Parser parser(fin);
-
-    YAML::Node doc;
     parser.GetNextDocument(doc);
+#endif
+
     for (int i = 0; i < doc.size(); i++)
     {
         dynamixel_spec spec;


### PR DESCRIPTION
The new yaml-cpp API removes the "node >> outputvar;" operator, and
it has a new way of loading documents. There's no version hint in the
library's headers, so I'm getting the version number from pkg-config.

This part of the patch is a port of the ones created by @ktossell for
map_server and other packages.

The new yaml-cpp also uses a different method for loading documents.
