### PR TITLE
Do not find_package(yaml-cpp)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,15 +8,14 @@ find_package(catkin REQUIRED COMPONENTS dynamixel_pro_driver roscpp roslib senso
 
 ## System dependencies are found with CMake's conventions
 #find_package(Boost REQUIRED COMPONENTS system yaml-cpp)
-find_package(yaml-cpp)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(yaml-cpp REQUIRED yaml-cpp)
 
 # There's no version hint in the yaml-cpp headers, so get the version number
 # from pkg-config.
-find_package(PkgConfig)
-pkg_check_modules(NEW_YAMLCPP yaml-cpp>=0.5)
-if(NEW_YAMLCPP_FOUND)
+if(NOT ${yaml-cpp_VERSION} VERSION_LESS "0.5")
 add_definitions(-DHAVE_NEW_YAMLCPP)
-endif(NEW_YAMLCPP_FOUND)
+endif(NOT ${yaml-cpp_VERSION} VERSION_LESS "0.5")
 
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
@@ -70,6 +69,7 @@ catkin_package(
 ## Your package locations should be listed before other locations
 include_directories(include
   ${catkin_INCLUDE_DIRS}
+  ${yaml-cpp_INCLUDE_DIRS}
 )
 
 ## Declare a cpp library
@@ -87,7 +87,7 @@ add_executable(dynamixel_pro_controller_node src/dynamixel_pro_controller.cpp)
 ## Specify libraries to link a library or executable target against
  target_link_libraries(dynamixel_pro_controller_node
    ${catkin_LIBRARIES}
-   yaml-cpp
+   ${yaml-cpp_LIBRARIES}
  )
 
 #############


### PR DESCRIPTION
While it appears that https://github.com/baxelrod/dynamixel_pro_controller/commit/94d6859f55bd8061676c13ad55a220e027bd9dc2 fixed the compilation problems in the buildfarm with yaml-cpp, adding the dep in the `package.xml` is the portion that actually fixed the problem. In actuality, the `find_package(yaml-cpp)` is failing on all current releases of Ubuntu and Fedora, as there is no `Findyaml-cpp.cmake` packaged with the system's yaml-cpp. The reason that this is not a fatal error is that you are currently hard-coding the library name and not using what WOULD be set from the `find_package`.

It would suffice to simply remove the `find_package(yaml-cpp)` from `CMakeLists.txt`, but it would likely be better to also start using the pkgconfig's value (from https://github.com/baxelrod/dynamixel_pro_controller/pull/2) at https://github.com/baxelrod/dynamixel_pro_controller/blob/master/CMakeLists.txt#L83 instead of hard-coding the library name.

If the other PR gets merged, I can generate another PR that does this, if you like.

On another note, I don't believe that `rosdep.yaml` files are used any more in light of the rosdep database in rosdistro.

Thanks,

--scott
